### PR TITLE
various changes/improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,27 +6,41 @@ import (
 	"log"
 	"net"
 	"fmt"
-	"strings"
+	"bytes"
 	"time"
 	"github.com/cheggaaa/pb"
 	"sync"
+	"encoding/json"
+	"math/rand"
+	"bufio"
 )
 
 const (
+	SET = "set %s 0 0 %d\r\n"
 	GET = "get %s\r\n"
-	SET = "set %s 0 0 %d\r\n%s\r\n"
 )
+
+type McCmd struct {
+	command int
+	cmdstr []byte
+	validx int
+}
 
 var (
 	host = flag.String("host", ":11211", "Host of memcache server")
-	size = flag.Int("size", 1000, "Size of key value")
+	minsize = flag.Int("minsize", 1000, "Min size of key value")
+	maxsize = flag.Int("maxsize", 1000, "Max size of key value")
 	iterations = flag.Int("n", 100, "How many requests total")
 	workers = flag.Int("workers", 100, "Number of workers")
+	ratio = flag.Int("sets", 100, "Percentage of SETs from total operations")
+	prefixweights = flag.String("prefixes", "{}", "Key prefix and their weights (frequency), in JSON format")
 )
 
-var value string
+var value []byte
+var weights map[string]interface{}
+var prefixes []string
 
-func listen(channel chan string, wg *sync.WaitGroup, bar *pb.ProgressBar) {
+func listen(channel chan McCmd, wg *sync.WaitGroup, bar *pb.ProgressBar) {
 	socket, err := net.Dial("tcp", *host)
 	if err != nil {
 		log.Fatal(err)
@@ -34,9 +48,23 @@ func listen(channel chan string, wg *sync.WaitGroup, bar *pb.ProgressBar) {
 	}
 	defer socket.Close()
 
+	buf := bufio.NewReader(socket)
+
 	for {
-		key := <- channel
-		fmt.Fprintf(socket, SET, key, *size, value)
+		cmd := <- channel
+		// send command
+		socket.Write(cmd.cmdstr)
+		if cmd.command == 0 {
+			socket.Write(value[cmd.validx:])
+			buf.ReadBytes('\n')
+		} else {
+			for {
+				retmsg, _ := buf.ReadBytes('\n')
+				if string(retmsg) == "END\r\n" {
+					break
+				}
+			}
+		}
 		bar.Increment()
 		wg.Done()
 	}
@@ -49,19 +77,60 @@ func main() {
 	bar := pb.New(*iterations)
 	wg := new(sync.WaitGroup)
 	log.Printf("Making %d workers...", *workers)
-	channels := make([]chan string, *workers)
+	channels := make([]chan McCmd, *workers)
 	for i = 0; i < *workers; i++ {
-		channels[i] = make(chan string)
+		channels[i] = make(chan McCmd)
 		go listen(channels[i], wg, bar)
 	}
-	value = strings.Repeat("x", *size)
-	keys := make([]string, *iterations)
+	value = append(bytes.Repeat([]byte("x"), *maxsize), []byte("\r\n")...)
+	keys := make([]McCmd, *iterations)
 	// log.Print(value)
 	log.Printf("Precalculating all %d keys...", *iterations)
+	json.Unmarshal([]byte(*prefixweights), &weights)
+	for k, v := range weights {
+		// log.Printf("prefix: %v weight: %v", k,v)
+		pfx := make([]string, int(v.(float64)))
+		for i = range pfx {
+			pfx[i] = k
+		}
+		prefixes = append(prefixes, pfx...)
+	}
+	prefixcount := len(prefixes)
+	// log.Printf("prefixes: %v %v", prefixcount, prefixes)
+	rand.Seed(time.Now().Unix())
 	for i = 0; i < *iterations; i++ {
 		// log.Printf("%s", i)
-		keys[i] = fmt.Sprintf("thread_id=%d&last_modifed=12345679&order=1&secure=0", i)
+		// shuffle keys while they are still being generated
+		j := rand.Intn(i + 1)
+                keys[i].command = keys[j].command
+		if int((float64(i) / float64(*iterations)) * 100) < *ratio {
+			keys[j].command = 0
+		} else {
+			keys[j].command = 1
+		}
+		prefix := ""
+		if prefixcount > 0 {
+			prefix = prefixes[int((float64(i) / float64(*iterations)) * float64(prefixcount))]
+		}
+                j = rand.Intn(i + 1)
+                keys[i].cmdstr = keys[j].cmdstr
+		keys[j].cmdstr = []byte(fmt.Sprintf("%sthread_id=%d&last_modifed=12345679&order=1&secure=0", prefix, i))
 	}
+	log.Print("Generating commands...")
+	for i = 0; i < *iterations; i++ {
+		if keys[i].command == 0 {
+			valsize := *minsize + rand.Intn(*maxsize - *minsize + 1)
+			keys[i].cmdstr = []byte(fmt.Sprintf(SET, keys[i].cmdstr, valsize))
+			keys[i].validx = *maxsize - valsize
+		} else {
+			keys[i].cmdstr = []byte(fmt.Sprintf(GET, keys[i].cmdstr))
+		}
+		// log.Printf("keys[%d]:", i)
+		// log.Printf("command: %d", keys[i].command)
+		// log.Printf("cmdstr: %s", keys[i].cmdstr)
+		// log.Printf("validx: %d", keys[i].validx)
+	}
+	// log.Printf("keys: %v", keys)
 
 	log.Printf("Rock and roll.")
 	bar.Start()

--- a/main.go
+++ b/main.go
@@ -84,11 +84,9 @@ func main() {
 	}
 	value = append(bytes.Repeat([]byte("x"), *maxsize), []byte("\r\n")...)
 	keys := make([]McCmd, *iterations)
-	// log.Print(value)
 	log.Printf("Precalculating all %d keys...", *iterations)
 	json.Unmarshal([]byte(*prefixweights), &weights)
 	for k, v := range weights {
-		// log.Printf("prefix: %v weight: %v", k,v)
 		pfx := make([]string, int(v.(float64)))
 		for i = range pfx {
 			pfx[i] = k
@@ -96,10 +94,8 @@ func main() {
 		prefixes = append(prefixes, pfx...)
 	}
 	prefixcount := len(prefixes)
-	// log.Printf("prefixes: %v %v", prefixcount, prefixes)
 	rand.Seed(time.Now().Unix())
 	for i = 0; i < *iterations; i++ {
-		// log.Printf("%s", i)
 		// shuffle keys while they are still being generated
 		j := rand.Intn(i + 1)
                 keys[i].command = keys[j].command
@@ -125,12 +121,7 @@ func main() {
 		} else {
 			keys[i].cmdstr = []byte(fmt.Sprintf(GET, keys[i].cmdstr))
 		}
-		// log.Printf("keys[%d]:", i)
-		// log.Printf("command: %d", keys[i].command)
-		// log.Printf("cmdstr: %s", keys[i].cmdstr)
-		// log.Printf("validx: %d", keys[i].validx)
 	}
-	// log.Printf("keys: %v", keys)
 
 	log.Printf("Rock and roll.")
 	bar.Start()


### PR DESCRIPTION
I stumbled upon this tool while looking for something to stress-test a mcrouter cluster, and while it did a great job, there were a couple of changes and features that I needed to have the generated data match real-world traffic:

1. variable value size - instead of a fixed size, you can now specify a min and max length, and keys are generated with a random length.
2. configurable set/get ratio - since our worst case is never just sets and no gets (famous last words, I know), you can now specify the percentage of total commands that are sets, and the rest will be gets, with the caveat that unless repeating a test, the queried keys will not be found. As a consequence of this addition, the tool now reads from the socket after every write, otherwise receiving buffers would quickly fill up and the connections would fail.
3. key prefixes - since we're using prefix-based routing with mcrouter, we needed the generated key names to match our rules; to use this feature you provide a JSON with each prefix and an associated weight - arbitrary values that have meaning only to each other (i.e. if you have 4 prefixes, each with a weight of 13, you'll get an even distribution of 25% for each prefix). To prevent a sweeping effect, where only one bucket is tested at a time, the generated keys are shuffled around. An example prefix list:
`{"bucket1:": 40, "bucket2:": 30, "bucket3:": 15, "bucket4:": 15}`
An improvement would be to have value size ranges specific to each prefix/bucket.

Commands are also now built as []bytes instead of strings, mainly because I'm a Go noob and I was told it would be faster to send data out the socket this way.